### PR TITLE
Deep and conditional cloning

### DIFF
--- a/Cloneable.Sample/Cloneable.Sample.csproj
+++ b/Cloneable.Sample/Cloneable.Sample.csproj
@@ -7,9 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Cloneable\Cloneable.csproj"
-				        OutputItemType="Analyzer"
-				        ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\Cloneable\Cloneable.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
 </Project>

--- a/Cloneable.Sample/DeepClone.cs
+++ b/Cloneable.Sample/DeepClone.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Cloneable.Sample
+{
+    [Cloneable]
+    public partial class DeepClone
+    {
+        public string A { get; set; }
+        public SimpleClone Simple { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(DeepClone)}:{Environment.NewLine}" +
+                $"\tA:\t{A}" +
+                Environment.NewLine +
+                $"\tSimple.A:\t{Simple?.A}" +
+                Environment.NewLine +
+                $"\tSimple.B:\t{Simple?.B}";
+        }
+    }
+}

--- a/Cloneable.Sample/Program.cs
+++ b/Cloneable.Sample/Program.cs
@@ -7,13 +7,77 @@ namespace Cloneable.Sample
         [STAThread]
         static void Main(string[] args)
         {
-            var a = new Foo()
+            DoSimpleClone();
+            DoSimpleExplicitClone();
+            DoDeepClone();
+            DoSafeDeepClone();
+        }
+
+        static void DoSimpleClone()
+        {
+            // Uses the Clone method on a class with no circular references
+            var obj = new SimpleClone()
             {
                 A = "salam",
                 B = 100
             };
-            var b = a.Clone();
-            Console.WriteLine(b);
+            var clone = obj.Clone();
+            Console.WriteLine(clone);
+            Console.WriteLine("Clone equals original: " + (clone == obj));
+            Console.WriteLine();
+        }
+
+        static void DoSimpleExplicitClone()
+        {
+            // Uses the Clone method on a class with no circular references
+            var obj = new SimpleCloneExplicit()
+            {
+                A = "salam",
+                B = 100
+            };
+            var clone = obj.Clone();
+            Console.WriteLine(clone);
+            Console.WriteLine("Clone equals original: " + (clone == obj));
+            Console.WriteLine();
+        }
+
+        static void DoDeepClone()
+        {
+            // Uses the Clone method on a class with no circular references
+            var obj = new SimpleClone()
+            {
+                A = "salam",
+                B = 100
+            };
+            var deep = new DeepClone()
+            {
+                A = "first",
+                Simple = obj
+            };
+            var clone = deep.Clone();
+            Console.WriteLine(clone);
+            Console.WriteLine("Clone equals original: " + (clone == deep));
+            Console.WriteLine();
+        }
+
+        static void DoSafeDeepClone()
+        {
+            // Uses the Clone method on a class with no circular references
+            var child = new SafeDeepCloneChild()
+            {
+                A = "child"
+            };
+            var parent = new SafeDeepClone()
+            {
+                A = "parent",
+                Child = child
+            };
+            child.Parent = parent;
+            var clone = parent.CloneSafe();
+            Console.WriteLine(clone);
+            Console.WriteLine("Clone equals original: " + (clone == parent));
+            Console.WriteLine("Is parents child copied: " + (clone.Child != parent.Child));
+            Console.WriteLine();
         }
     }
 }

--- a/Cloneable.Sample/SafeDeepClone.cs
+++ b/Cloneable.Sample/SafeDeepClone.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Cloneable.Sample
+{
+    [Cloneable]
+    public partial class SafeDeepClone
+    {
+        public string A { get; set; }
+        public SafeDeepCloneChild Child { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(SafeDeepClone)}:{Environment.NewLine}" +
+                $"\tA:\t{A}" +
+                Environment.NewLine +
+                $"\tChild.A:\t{Child?.A}";
+        }
+    }
+    [Cloneable]
+    public partial class SafeDeepCloneChild
+    {
+        public string A { get; set; }
+        public SafeDeepClone Parent { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(SafeDeepCloneChild)}:{Environment.NewLine}" +
+                   $"\tA:\t{A}" +
+                   Environment.NewLine +
+                   $"\tParent.A:\t{Parent?.A}";
+        }
+    }
+}

--- a/Cloneable.Sample/SimpleClone.cs
+++ b/Cloneable.Sample/SimpleClone.cs
@@ -3,19 +3,16 @@ using System;
 namespace Cloneable.Sample
 {
     [Cloneable]
-    public partial class Foo
+    public partial class SimpleClone
     {
         public string A { get; set; }
+        
+        [IgnoreClone]
         public int B { get; set; }
-
-        public Foo()
-        {
-
-        }
 
         public override string ToString()
         {
-            return $"Foo:{Environment.NewLine}" +
+            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
                 $"\tA:\t{A}" +
                 Environment.NewLine +
                 $"\tB:\t{B}";

--- a/Cloneable.Sample/SimpleCloneExplicit.cs
+++ b/Cloneable.Sample/SimpleCloneExplicit.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Cloneable.Sample
+{
+    [Cloneable(ExplicitDeclaration = true)]
+    public partial class SimpleCloneExplicit
+    {
+        public string A { get; set; }
+     
+        [Clone]
+        public int B { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(SimpleCloneExplicit)}:{Environment.NewLine}" +
+                $"\tA:\t{A}" +
+                Environment.NewLine +
+                $"\tB:\t{B}";
+        }
+    }
+}

--- a/Cloneable/CloneableGenerator.cs
+++ b/Cloneable/CloneableGenerator.cs
@@ -15,15 +15,48 @@ namespace Cloneable
 
 namespace Cloneable
 {
-    [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = true, AllowMultiple = false)]
     public sealed class CloneableAttribute : Attribute
     {
+        private bool explicitDeclaration;
         public CloneableAttribute()
+        {
+        }
+
+        public bool ExplicitDeclaration { get => explicitDeclaration; set => explicitDeclaration = value; }
+    }
+}
+";
+        private const string clonePropertyAttributeText = @"using System;
+
+namespace Cloneable
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public sealed class CloneAttribute : Attribute
+    {
+        public CloneAttribute()
         {
         }
     }
 }
 ";
+        private const string ignoreClonePropertyAttributeText = @"using System;
+
+namespace Cloneable
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public sealed class IgnoreCloneAttribute : Attribute
+    {
+        public IgnoreCloneAttribute()
+        {
+        }
+    }
+}
+";
+
+        private INamedTypeSymbol cloneableAttribute;
+        private INamedTypeSymbol ignoreCloneAttribute;
+        private INamedTypeSymbol cloneAttribute;
 
         public void Initialize(GeneratorInitializationContext context)
         {
@@ -32,7 +65,7 @@ namespace Cloneable
 
         public void Execute(GeneratorExecutionContext context)
         {
-            InjectCloneableAttribute(context);
+            InjectCloneableAttributes(context);
             GenerateCloneMethods(context);
         }
 
@@ -41,77 +74,130 @@ namespace Cloneable
             if (context.SyntaxReceiver is not SyntaxReceiver receiver)
                 return;
 
-            var classSymbols = GetClassSymbols(context, receiver);
+            var options = (context.Compilation as CSharpCompilation).SyntaxTrees[0].Options as CSharpParseOptions;
+            
+            var compilation = context.Compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(SourceText.From(cloneableAttributeText, Encoding.UTF8), options)).
+                AddSyntaxTrees(CSharpSyntaxTree.ParseText(SourceText.From(clonePropertyAttributeText, Encoding.UTF8), options)).
+                AddSyntaxTrees(CSharpSyntaxTree.ParseText(SourceText.From(ignoreClonePropertyAttributeText, Encoding.UTF8), options));
+
+            cloneableAttribute = compilation.GetTypeByMetadataName("Cloneable.CloneableAttribute")!;
+            cloneAttribute = compilation.GetTypeByMetadataName("Cloneable.CloneAttribute")!;
+            ignoreCloneAttribute = compilation.GetTypeByMetadataName("Cloneable.IgnoreCloneAttribute")!;
+
+            var classSymbols = GetClassSymbols(compilation, cloneableAttribute, receiver);
             foreach (var classSymbol in classSymbols)
             {
-                context.AddSource($"{classSymbol.Name}_cloneable.cs", SourceText.From(CreateCloneableCode(classSymbol), Encoding.UTF8));
+                var attribute = classSymbol.GetAttributes().First(x => x.AttributeClass.Equals(cloneableAttribute));
+                var isExplicit = (bool?)attribute.NamedArguments.FirstOrDefault(e => e.Key.Equals("ExplicitDeclaration")).Value.Value ?? false;
+                context.AddSource($"{classSymbol.Name}_cloneable.cs", SourceText.From(CreateCloneableCode(classSymbol, isExplicit), Encoding.UTF8));
             }
         }
 
-        private string CreateCloneableCode(INamedTypeSymbol classSymbol)
+        private string CreateCloneableCode(INamedTypeSymbol classSymbol, bool isExplicit)
         {
             string namespaceName = classSymbol.ContainingNamespace.ToDisplayString();
-            string fieldAssignmentsCode = GenerateFieldAssignmentsCode(classSymbol);
+            var fieldAssignmentsCode = GenerateFieldAssignmentsCode(classSymbol, isExplicit, false);
+            var fieldAssignmentsCodeSafe = fieldAssignmentsCode.Select(x =>
+            {
+                if (x.EndsWith("?.Clone"))
+                    return x + "Safe(referenceChain)";
+                return x;
+            });
+            fieldAssignmentsCode = fieldAssignmentsCode.Select(x =>
+            {
+                if (x.EndsWith("?.Clone"))
+                    return x + "()";
+                return x;
+            });
 
-            return $@"namespace {namespaceName}
+            return $@"using System.Collections.Generic;
+
+namespace {namespaceName}
 {{
     {GetAccessModifier(classSymbol)} partial class {classSymbol.Name}
     {{
+        /// <summary>
+        /// Creates a copy of {classSymbol.Name} with NO circular reference checking. This method should be used if performance matters or on ""true"" struct types (struct types without object references).
+        /// 
+        /// <exception cref=""StackOverflowException"">Will occur on any object that has circular references in the hierarchy.</exception>
+        /// </summary>
         public {classSymbol.Name} Clone()
         {{
             return new {classSymbol.Name}
             {{
-{fieldAssignmentsCode}
+{string.Join($",{Environment.NewLine}", fieldAssignmentsCode)}
             }};
+        }}
+
+        /// <summary>
+        /// Creates a copy of {classSymbol.Name} with circular reference checking. If a circular reference was detected, only a reference of the leaf object is passed instead of cloning it.
+        /// </summary>
+        /// <param name=""referenceChain"">Should only be provided if specific objects should not be cloned but passed by reference instead.</param>
+        public {classSymbol.Name} CloneSafe(Stack<object> referenceChain = null)
+        {{
+            if(referenceChain?.Contains(this) == true) 
+                return this;
+            referenceChain ??= new Stack<object>();
+            referenceChain.Push(this);
+            var result = new {classSymbol.Name}
+            {{
+{string.Join($",{Environment.NewLine}", fieldAssignmentsCodeSafe)}
+            }};
+            referenceChain.Pop();
+            return result;
         }}
     }}
 }}";
         }
 
-        private static string GenerateFieldAssignmentsCode(INamedTypeSymbol classSymbol)
+        private IEnumerable<string> GenerateFieldAssignmentsCode(INamedTypeSymbol classSymbol, bool isExplicit, bool safe)
         {
-            var fieldNames = GetFieldsAndProperties(classSymbol);
-            var fieldAssignments = fieldNames.Select(x => $@"                {x} = this.{x}");
-            var fieldAssignmentsCode = string.Join($",{Environment.NewLine}", fieldAssignments);
-            return fieldAssignmentsCode;
+            var fieldNames = GetCloneableProperties(classSymbol, isExplicit);
+            var fieldAssignments = fieldNames.Select(x =>
+                {
+                    bool isCloneable = x.Type != classSymbol && 
+                                       x.Type.GetAttributes().Any(a => a.AttributeClass == cloneableAttribute);
+                    return (item: x, isCloneable);
+                }).
+                OrderBy(x => x.isCloneable).
+                Select(x =>
+                {
+                    var name = x.item.Name;
+                    if (x.isCloneable)
+                    {
+                        return $@"                {name} = this.{name}?.Clone";
+                    }
+                    return $@"                {name} = this.{name}";
+                });
+            return fieldAssignments;
         }
 
-        private static string GetAccessModifier(INamedTypeSymbol classSymbol)
+        private string GetAccessModifier(INamedTypeSymbol classSymbol)
         {
             return classSymbol.DeclaredAccessibility.ToString().ToLowerInvariant();
         }
 
-        private static IEnumerable<string> GetFieldsAndProperties(INamedTypeSymbol classSymbol)
+        private IEnumerable<IPropertySymbol> GetCloneableProperties(ITypeSymbol classSymbol, bool isExplicit)
         {
-            IEnumerable<string> properties = GetProperties(classSymbol);
-            IEnumerable<string> fields = GetFields(classSymbol);
-            return properties.Concat(fields);
+            var enumerable = classSymbol.GetMembers().OfType<IPropertySymbol>()
+                .Where(x => x.SetMethod is not null &&
+                            x.CanBeReferencedByName);
+            if (isExplicit)
+            {
+                enumerable = enumerable.Where(x =>
+                    x.GetAttributes().Any(a => a.AttributeClass == cloneAttribute));
+            }
+            else
+            {
+                enumerable = enumerable.Where(x =>
+                    !x.GetAttributes().Any(a => a.AttributeClass.Equals(ignoreCloneAttribute)));
+            }
+
+            return enumerable;
         }
 
-        private static IEnumerable<string> GetFields(INamedTypeSymbol classSymbol)
+        private static List<INamedTypeSymbol> GetClassSymbols(Compilation compilation, INamedTypeSymbol cloneableAttributeSymbol, SyntaxReceiver receiver)
         {
-            return classSymbol.GetMembers().OfType<IFieldSymbol>()
-               .Where(x => x.CanBeReferencedByName)
-               .Select(fieldSymbol => $"{fieldSymbol.Name}")
-               .ToList();
-        }
-
-        private static IEnumerable<string> GetProperties(INamedTypeSymbol classSymbol)
-        {
-            return classSymbol.GetMembers().OfType<IPropertySymbol>()
-                .Where(x => x.SetMethod is not null)
-                .Where(x => x.CanBeReferencedByName)
-                .Select(propertySymbol => $"{propertySymbol.Name}")
-                .ToList();
-        }
-
-        private static List<INamedTypeSymbol> GetClassSymbols(GeneratorExecutionContext context, SyntaxReceiver receiver)
-        {
-            var options = (context.Compilation as CSharpCompilation).SyntaxTrees[0].Options as CSharpParseOptions;
-            var compilation = context.Compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(SourceText.From(cloneableAttributeText, Encoding.UTF8), options));
-
-            var cloneableAttributeSymbol = compilation.GetTypeByMetadataName("Cloneable.CloneableAttribute")!;
-
             var classSymbols = new List<INamedTypeSymbol>();
             foreach (var clazz in receiver.CandidateClasses)
             {
@@ -137,9 +223,11 @@ namespace Cloneable
             return classSymbol;
         }
 
-        private static void InjectCloneableAttribute(GeneratorExecutionContext context)
+        private static void InjectCloneableAttributes(GeneratorExecutionContext context)
         {
             context.AddSource("CloneableAttribute", SourceText.From(cloneableAttributeText, Encoding.UTF8));
+            context.AddSource("ClonePropertyAttribute", SourceText.From(clonePropertyAttributeText, Encoding.UTF8));
+            context.AddSource("IgnoreClonePropertyAttribute", SourceText.From(ignoreClonePropertyAttributeText, Encoding.UTF8));
         }
     }
 }

--- a/Cloneable/CloneableGenerator.cs
+++ b/Cloneable/CloneableGenerator.cs
@@ -34,9 +34,11 @@ namespace Cloneable
     [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
     public sealed class CloneAttribute : Attribute
     {
+        private bool preventDeepCopy;
         public CloneAttribute()
         {
         }
+        public bool PreventDeepCopy { get => preventDeepCopy; set => preventDeepCopy = value; }
     }
 }
 ";
@@ -156,7 +158,8 @@ namespace {namespaceName}
             var fieldAssignments = fieldNames.Select(x =>
                 {
                     bool isCloneable = x.Type != classSymbol && 
-                                       x.Type.GetAttributes().Any(a => a.AttributeClass == cloneableAttribute);
+                                       x.Type.GetAttributes().Any(a => a.AttributeClass == cloneableAttribute && 
+                                                                       !x.GetAttributes().Any(i => (bool?)i.NamedArguments.FirstOrDefault(e => e.Key.Equals("PreventDeepCopy")).Value.Value ?? false));
                     return (item: x, isCloneable);
                 }).
                 OrderBy(x => x.isCloneable).

--- a/Cloneable/CloneableGenerator.cs
+++ b/Cloneable/CloneableGenerator.cs
@@ -119,7 +119,7 @@ namespace {namespaceName}
     {GetAccessModifier(classSymbol)} partial class {classSymbol.Name}
     {{
         /// <summary>
-        /// Creates a copy of {classSymbol.Name} with NO circular reference checking. This method should be used if performance matters or on ""true"" struct types (struct types without object references).
+        /// Creates a copy of {classSymbol.Name} with NO circular reference checking. This method should be used if performance matters.
         /// 
         /// <exception cref=""StackOverflowException"">Will occur on any object that has circular references in the hierarchy.</exception>
         /// </summary>


### PR DESCRIPTION
## Changes
- Only properties are now cloneable (previously it was possible to clone a field and the corresponding property)
- Added more examples
- Added documentation to generated methods
- New property attribute `[Clone]`
  - `[Clone]` allows to explicitly clone a property (only makes sense with `Cloneable(ExplicitDeclaration = true)`)
  - `[Clone(PreventDeepCopy = true)]` can (always) be used to prevent a cloneable property from being clones and instead pass it's being passed by reference
- New property attribute `[IgnoreClone]`
  - `[IgnoreClone]` prevents a property completely from being cloned and works only if `ExplicitDeclaration` is `false` or not set
- New method `CloneSafe` keeps track of circular references and if it finds one, it's passed by reference

#### Note: `CloneSafe` will run slower than `Clone` because it always checks the call stack for existing references
  
### Example Generated Code
Existing class which should be made cloneable:
``` csharp
[Cloneable]
public partial class SafeDeepClone
{
	public string A { get; set; }
	public SafeDeepCloneChild Child { get; set; }
	
	[Clone(PreventDeepCopy = true)]
	public SafeDeepCloneChild Child2 { get; set; }
}

[Cloneable]
public partial class SafeDeepCloneChild
{
	public string A { get; set; }
	public SafeDeepClone Parent { get; set; }
}
```

Generated code (`SafeDeepCloneChild` generated code is excluded):
``` csharp
/// <summary>
/// Creates a copy of SafeDeepClone with NO circular reference checking. This method should be used if performance matters or on "true" struct types (struct types without object references).
/// 
/// <exception cref="StackOverflowException">Will occur on any object that has circular references in the hierarchy.</exception>
/// </summary>
public SafeDeepClone Clone()
{
	return new SafeDeepClone
	{
		A = this.A,
		Child2 = this.Child2,
		Child = this.Child?.Clone()
	};
}

/// <summary>
/// Creates a copy of SafeDeepClone with circular reference checking. If a circular reference was detected, only a reference of the leaf object is passed instead of cloning it.
/// </summary>
/// <param name="referenceChain">Should only be provided if specific objects should not be cloned but passed by reference instead.</param>
public SafeDeepClone CloneSafe(Stack<object> referenceChain = null)
{
	if(referenceChain?.Contains(this) == true) 
		return this;
	referenceChain ??= new Stack<object>();
	referenceChain.Push(this);
	var result = new SafeDeepClone
	{
		A = this.A,
		Child2 = this.Child2,
		Child = this.Child?.CloneSafe(referenceChain)
	};
	referenceChain.Pop();
	return result;
}
```
